### PR TITLE
Fixes for cluster deployments

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -21,6 +21,7 @@ exclude_paths:
   - playbooks/template_cloudinit_config.yml
   - playbooks/specific_edges_to_teardown.yml
   - roles/aws_teardown/tasks/main.yml
+  - .ansible
 # parseable: true
 # quiet: true
 # strict: true

--- a/roles/aws_edges/tasks/aws_cedge_ec2_instance.yml
+++ b/roles/aws_edges/tasks/aws_cedge_ec2_instance.yml
@@ -38,7 +38,7 @@
 
 - name: Set aws_network_interfaces fact with a list of interfaces for cEdge device
   ansible.builtin.set_fact:
-    aws_network_interfaces: "{{ network_interfaces_cedge.results | map(attribute='interface') | list }}"
+    aws_network_interfaces: "{{ network_interfaces_cedge.results | selectattr('interface', 'defined') | map(attribute='interface') | list }}"
 
 - name: Filter aws_network_interfaces for instance creation. Set aws_mgmt_nic and aws_transport_nic facts
   ansible.builtin.set_fact:

--- a/roles/azure_controllers/tasks/azure_vmanage_vm.yml
+++ b/roles/azure_controllers/tasks/azure_vmanage_vm.yml
@@ -107,6 +107,36 @@
     - cluster_subnet is defined
     - cluster_subnet != ""
 
+- name: "Get info about NSG: {{ az_network_security_group }}"
+  azure.azcollection.azure_rm_securitygroup_info:
+    resource_group: "{{ az_resource_group }}"
+    name: "{{ az_network_security_group }}"
+  register: az_res_gr
+  when:
+    - cluster_subnet is defined
+    - cluster_subnet != ""
+
+- name: "Extend Network Security Group for cluster deployment. NSG: {{ az_network_security_group }}"
+  azure.azcollection.azure_rm_securitygroup:
+    resource_group: "{{ az_resource_group }}"
+    name: "{{ az_network_security_group }}"
+    rules:
+      - name: "{{ cluster_vmanage_nic.state.name }}"
+        protocol: "*"
+        destination_port_range: "*"
+        source_port_range: "*"
+        source_address_prefix: "{{ cluster_vmanage_nic.state.ip_configuration.private_ip_address }}"
+        access: Allow
+        priority: "{{ 2500 + ((az_res_gr.securitygroups | first).rules | length) + 1 }}"
+        direction: Inbound
+    tags:
+      Name: "{{ az_network_security_group }}"
+      Creator: "{{ az_tag_creator }}"
+      Organization: "{{ organization_name }}"
+  when:
+    - cluster_subnet is defined
+    - cluster_subnet != ""
+
 - name: Set az_network_interfaces_vmanage fact with a list of interfaces for vmanage
   ansible.builtin.set_fact:
     az_network_interfaces_vmanage: "{{ (vmanage_nics.results + [cluster_vmanage_nic]) | selectattr('state', 'defined') | map(attribute='state') | list }}"


### PR DESCRIPTION
# Pull Request summary:
Following issues was discovered in cluster deployments:

1. AWS cluster deployment could not be run due to error in aws_edges role
2. Azure cluster deployment was missing some network security group rules required for communication between Manager nodes

# Description of changes:

1. In aws_edges role additional filter was added to ignore invalid elements.
2. When Manager is created in cluster setup, additional NSG rule in created 

# Checklist:

- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
