### PR TITLE
Change data disk path in Azure cloudinit template

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -21,6 +21,7 @@ exclude_paths:
   - playbooks/template_cloudinit_config.yml
   - playbooks/specific_edges_to_teardown.yml
   - roles/aws_teardown/tasks/main.yml
+  - .ansible
 # parseable: true
 # quiet: true
 # strict: true

--- a/roles/azure_controllers/templates/userdata_vmanage.j2
+++ b/roles/azure_controllers/templates/userdata_vmanage.j2
@@ -16,13 +16,13 @@ disk_setup:
     layout: false
     overwrite: false
 fs_setup:
-- device: /dev/disk/azure/scsi1/lun10
+- device: /dev/sdc
   label: data
   partition: none
   filesystem: ext4
   overwrite: false
 mounts:
-- [ /dev/disk/azure/scsi1/lun10, /opt/data ]
+- [ /dev/sdc, /opt/data ]
 
 write_files:
 - path: /opt/web-app/etc/persona


### PR DESCRIPTION
# Pull Request summary:
During upgrade tests I discovered that /dev/disk/azure/scsi1/lun10 cannot be looked up in blkid. Incorrect record is added to /etc/fstab which break Manager after reboot. This PR fixes this issue.

# Description of changes:
In azure_controllers role data device path was changed from /dev/disk/azure/scsi1/lun10 to /dev/sdc

# Checklist:

- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
