### PR TITLE
Add enterprise root CA to cEdge's bootstrap

### DIFF
--- a/roles/aws_edges/tasks/aws_cedge_ec2_instance.yml
+++ b/roles/aws_edges/tasks/aws_cedge_ec2_instance.yml
@@ -79,7 +79,8 @@
     src: ./bootstrap_cedge.j2
     dest: "{{ userdata_cedge_templated }}"
     mode: "0644"
-
+  vars:
+    enterprise_root_ca: "{{ lookup('file', enterprise_ca_cert_path | default(results_dir~'/certificates/ca.crt')) }}"
 
 - name: Set interfaces fact
   ansible.builtin.set_fact:

--- a/roles/aws_edges/templates/bootstrap_cedge.j2
+++ b/roles/aws_edges/templates/bootstrap_cedge.j2
@@ -13,6 +13,14 @@ vinitparam:
  - otp : {{ otp }}
  - org : {{ organization_name }}
  - vbond: {{ vbond }}
+{% if controller_certificate_auth is defined and controller_certificate_auth == "enterprise" %}
+ - rcc : true
+ca-certs:
+  remove-defaults: false
+  trusted:
+  - |
+   {{ enterprise_root_ca | indent(3) }}
+{% endif %}
 
 
 --===============0630588950316195806==


### PR DESCRIPTION
# Pull Request summary:
When enterprise root CA is in use, CA certificate must be added to Edge's bootstrap file

# Description of changes:
When controller_certificate_auth is set to enterprise include enterprise root CA in Edge bootstrap

# Checklist:

- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
