### PR TITLE
Azure edges: default gateway on both interfaces

### DIFF
--- a/roles/azure_edges/tasks/azure_cedge_vm.yml
+++ b/roles/azure_edges/tasks/azure_cedge_vm.yml
@@ -133,13 +133,11 @@
 
 - name: "Set vpn0_default_gateway fact from VPN 0 subnet value"
   ansible.builtin.set_fact:
-    vpn0_default_gateway: "{{ subnet.cidr | ansible.utils.ipaddr('1') | ansible.utils.ipaddr('address') }}"
-  loop: "{{ az_subnets }}"
-  loop_control:
-    loop_var: subnet
-  when:
-    - subnet.VPN == 0
-    - subnet.type != "cluster"
+    vpn0_default_gateway: "{{ vpn0_subnet | ansible.utils.ipaddr('1') | ansible.utils.ipaddr('address') }}"
+    vpn512_default_gateway: "{{ vpn512_subnet | ansible.utils.ipaddr('1') | ansible.utils.ipaddr('address') }}"
+  vars:
+    vpn0_subnet: "{{ az_subnets | json_query('[?VPN==`0` && type!=`cluster`].cidr | [0]') }}"
+    vpn512_subnet: "{{ az_subnets | json_query('[?VPN==`512` && type!=`cluster`].cidr | [0]') }}"
 
 - name: "Set path for bootstrap configuration: {{ userdata_cedge_path }}-{{ hostname }}"
   ansible.builtin.set_fact:

--- a/roles/azure_edges/templates/userdata_cedge.j2
+++ b/roles/azure_edges/templates/userdata_cedge.j2
@@ -197,6 +197,8 @@ Content-Disposition: attachment; filename="config-{{ uuid }}.txt"
    mtu           1500
    negotiation auto
   exit
+  ip route 0.0.0.0 0.0.0.0 {{ vpn512_default_gateway }}
+  ip route 0.0.0.0 0.0.0.0 {{ vpn0_default_gateway }}
   interface Tunnel1
    no shutdown
    ip unnumbered GigabitEthernet1

--- a/roles/azure_edges/templates/userdata_cedge.j2
+++ b/roles/azure_edges/templates/userdata_cedge.j2
@@ -13,6 +13,14 @@ vinitparam:
  - otp : {{ otp }}
  - org : {{ organization_name }}
  - vbond: {{ vbond }}
+{% if controller_certificate_auth is defined and controller_certificate_auth == "enterprise" %}
+ - rcc : true
+ca-certs:
+  remove-defaults: false
+  trusted:
+  - |
+   {{ enterprise_root_ca | indent(3) }}
+{% endif %}
 
 
 --===============0630588950316195806==


### PR DESCRIPTION
# Pull Request Summary:

Due to a limitation in Azure, a virtual machine with multiple network interfaces receives a default gateway on only one interface. For controllers on Azure, this issue was resolved with an additional bootstrap configuration. This pull request extends the fix to Edge nodes.


# Description of Changes:

The Azure Edge now has two default gateways manually set in the bootstrap configuration.

# Checklist:

- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
