### PR TITLE
Deprecate aws_availibility_zone variable

### DIFF
--- a/playbooks/aws_sdwan_config.yml
+++ b/playbooks/aws_sdwan_config.yml
@@ -23,7 +23,6 @@ aws_allowed_subnets: null
 aws_region: us-east-1
 aws_resources_prefix: "{{ organization_name }}"
 aws_tag_creator: "{{ organization_name }}"
-aws_availibility_zone: us-east-1a  # we cannot use us-east-1e for c5.9xlarge, therefore we use us-east-1a
 
 # VPC
 aws_vpc_name: "{{ aws_resources_prefix }}-vpc"

--- a/roles/aws_edges/README.md
+++ b/roles/aws_edges/README.md
@@ -52,7 +52,6 @@ The following variables must be set prior to executing the role:
 
 - `organization_name`: Identifier for your organization, used for naming AWS resources.
 - `aws_region`: AWS region to host the resources.
-- `aws_availibility_zone`: Specific AWS availability zone within the selected region.
 - `admin_password`: Password for administrative access to controller instances.
 - `admin_ssh_keys`: List of SSH public keys authorized for admin login.
 - `aws_vpc_config`: Configuration details for the AWS VPC.

--- a/roles/aws_network_infrastructure/README.md
+++ b/roles/aws_network_infrastructure/README.md
@@ -52,7 +52,6 @@ Before running the role, define the following variables:
 
 - `organization_name`: The name of your organization, influencing AWS resource naming.
 - `aws_region`: The AWS region for deploying resources.
-- `aws_availibility_zone`: The desired AWS availability zone within the region.
 - `aws_allowed_subnets`: List of subnets allowed to interact with the AWS resources.
 
 ## Example Playbook

--- a/roles/aws_network_infrastructure/defaults/main.yml
+++ b/roles/aws_network_infrastructure/defaults/main.yml
@@ -17,7 +17,6 @@ organization_name: null  # has to be set by user
 aws_region: null
 aws_resources_prefix: "{{ organization_name }}"
 aws_tag_creator: "{{ organization_name }}"
-aws_availibility_zone: us-east-1a  # we cannot use us-east-1e for c5.9xlarge, therefore we use us-east-1a
 
 # VPC
 aws_vpc_name: "{{ aws_resources_prefix }}-vpc"

--- a/roles/aws_network_infrastructure/tasks/aws_create_network_infrastructure.yml
+++ b/roles/aws_network_infrastructure/tasks/aws_create_network_infrastructure.yml
@@ -65,7 +65,6 @@
     cidr: "{{ subnet_config.subnet_cidr }}"
     map_public: "{{ subnet_config.type in ['mgmt', 'transport'] }}"
     region: "{{ aws_region }}"
-    az: "{{ aws_availibility_zone }}"
     tags:
       Name: "{{ subnet_config.name }}"
       Creator: "{{ aws_tag_creator }}"

--- a/roles/aws_teardown/README.md
+++ b/roles/aws_teardown/README.md
@@ -37,7 +37,6 @@ This role provides a systematic approach to tearing down AWS resources, with a s
 - `teardown_only_instances`: Boolean value to indicate if only EC2 instances should be torn down.
 - `teardown_specific_instances`: Boolean value to indicate if specific EC2 instances should be torn down.
 - `aws_region`: AWS region where resources were deployed.
-- `aws_availibility_zone`: AWS availability zone used for resource deployment (default: `us-east-1a`).
 - `aws_vpc_name`, `aws_security_group_name`: Names for the VPC and security group to be removed.
 
 ## Example Playbook

--- a/roles/aws_teardown/defaults/main.yml
+++ b/roles/aws_teardown/defaults/main.yml
@@ -17,7 +17,6 @@ teardown_specific_instances: false
 aws_region: null
 aws_resources_prefix: "{{ organization_name }}"
 aws_tag_creator: "{{ organization_name }}"
-aws_availibility_zone: null  # we cannot use us-east-1e for c5.9xlarge, therefore we use us-east-1a
 
 aws_vpc_name: "{{ aws_resources_prefix }}-vpc"
 aws_security_group_name: "{{ aws_resources_prefix }}-sg"

--- a/roles/common/defaults/aws_required_vars_controllers.yml
+++ b/roles/common/defaults/aws_required_vars_controllers.yml
@@ -6,7 +6,6 @@
 required_variables:
   organization_name: "{{ organization_name }}"
   aws_region: "{{ aws_region }}"
-  aws_availibility_zone: "{{ aws_availibility_zone }}"
   admin_password: "{{ admin_password }}"
   aws_vpc_config: "{{ aws_vpc_config }}"
   aws_security_group_config: "{{ aws_security_group_config }}"

--- a/roles/common/defaults/aws_required_vars_edges.yml
+++ b/roles/common/defaults/aws_required_vars_edges.yml
@@ -6,7 +6,6 @@
 required_variables:
   organization_name: "{{ organization_name }}"
   aws_region: "{{ aws_region }}"
-  aws_availibility_zone: "{{ aws_availibility_zone }}"
   admin_password: "{{ admin_password }}"
   aws_vpc_config: "{{ aws_vpc_config }}"
   aws_security_group_config: "{{ aws_security_group_config }}"

--- a/roles/common/defaults/aws_required_vars_network_infrastructure.yml
+++ b/roles/common/defaults/aws_required_vars_network_infrastructure.yml
@@ -6,5 +6,4 @@
 required_variables:
   organization_name: "{{ organization_name }}"
   aws_region: "{{ aws_region }}"
-  aws_availibility_zone: "{{ aws_availibility_zone }}"
   aws_allowed_subnets: "{{ aws_allowed_subnets }}"


### PR DESCRIPTION
# Pull Request summary:
Part of https://github.com/cisco-en-programmability/ansible-collection-sdwan/pull/40

This PR removes aws_availibility_zone variable from available variables. Virtual machine will be created in default availability zone

# Checklist:

- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
