### PR TITLE
Launch AWS Edges in multiple AWS regions

### DIFF
--- a/roles/aws_edges/tasks/aws_cedge_ec2_instance.yml
+++ b/roles/aws_edges/tasks/aws_cedge_ec2_instance.yml
@@ -10,19 +10,43 @@
 # 2 aws_eip
 # 1 ec2 instance
 
+- name: Discover required information about network infrastructure if edge is in different zone
+  when: >
+    "region" not in all_aws_vpc_config
+    or "region" not in all_aws_security_group_config
+    or "region" not in all_aws_sunbnets_config
+  block:
+    - name: Gather network resources information
+      ansible.builtin.include_role:
+        name: aws_network_infrastructure
+        tasks_from: aws_gather_network_resources.yml
+      vars:
+        aws_region: "{{ region }}"
+
+    - name: Set reusable infrastructure facts from discovered variables
+      ansible.builtin.set_fact:
+        all_aws_vpc_config: "{{ all_aws_vpc_config | combine({region: aws_discovered_vpc}) }}"
+        all_aws_security_group_config: "{{ all_aws_security_group_config | combine({region: aws_discovered_security_group}) }}"
+        all_aws_subnets_config: "{{ all_aws_subnets_config | combine({region: aws_discovered_subnets}) }}"
+
+- name: Use information about network infrastructure from default region
+  ansible.builtin.set_fact:
+    aws_edge_vpc_config: "{{ all_aws_vpc_config[region] }}"
+    aws_edge_security_group_config: "{{ all_aws_security_group_config[region] }}"
+    aws_edge_subnets_config: "{{ all_aws_subnets_config[region] }}"
 
 # NICs
 - name: Filter required subnets for instance creation. Set aws_mgmt_subnet and aws_transport_subnet facts
   ansible.builtin.set_fact:
-    aws_mgmt_subnet: "{{ aws_subnets_config | selectattr('tags.type', 'equalto', 'mgmt') | list | first }}"
-    aws_transport_subnet: "{{ aws_subnets_config | selectattr('tags.type', 'equalto', 'transport') | list | first }}"
+    aws_mgmt_subnet: "{{ aws_edge_subnets_config | selectattr('tags.type', 'equalto', 'mgmt') | list | first }}"
+    aws_transport_subnet: "{{ aws_edge_subnets_config | selectattr('tags.type', 'equalto', 'transport') | list | first }}"
 
 - name: Create network interfaces for cedge
   amazon.aws.ec2_eni:
     subnet_id: "{{ subnet_item.id }}"
     description: Network interface for SD-WAN Controller
-    security_groups: "{{ aws_security_group_config.group_id }}"
-    region: "{{ aws_region }}"
+    security_groups: "{{ aws_edge_security_group_config.group_id }}"
+    region: "{{ region }}"
     tags:
       Name: "nic-{{ subnet_item.tags.Name }}"
       Creator: "{{ aws_tag_creator }}"
@@ -30,7 +54,7 @@
       VPN: "{{ subnet_item.tags.VPN }}"
       type: "{{ subnet_item.tags.type }}"
   register: network_interfaces_cedge
-  loop: "{{ aws_subnets_config }}"
+  loop: "{{ aws_edge_subnets_config }}"
   loop_control:
     loop_var: subnet_item
     label: "nic-{{ subnet_item.tags.Name }}"
@@ -50,7 +74,7 @@
 - name: Associate EIP with mgmt network interface
   amazon.aws.ec2_eip:
     device_id: "{{ interface_item.id }}"
-    region: "{{ aws_region }}"
+    region: "{{ region }}"
     in_vpc: true
     state: present
     tags:
@@ -106,10 +130,10 @@
     count: 1
     instance_type: "{{ aws_cedge_instance_type }}"
     image:
-      id: "{{ aws_cedge_ami_id }}"
+      id: "{{ ami }}"
     state: present
     vpc_subnet_id: "{{ aws_mgmt_subnet.id }}"
-    region: "{{ aws_region }}"
+    region: "{{ region }}"
     key_name: "{{ aws_key_name | default('') | bool | ternary(aws_key_name, omit) }}"
     network:
       assign_public_ip: false

--- a/roles/aws_edges/tasks/main.yml
+++ b/roles/aws_edges/tasks/main.yml
@@ -30,6 +30,16 @@
         aws_security_group_config: "{{ aws_discovered_security_group }}"
         aws_subnets_config: "{{ aws_discovered_subnets }}"
 
+- name: Cache network infrastructure information for default AWS region
+  ansible.builtin.set_fact:
+    all_aws_vpc_config:
+      "{{ aws_region }}": "{{ aws_discovered_vpc }}"
+    all_aws_security_group_config:
+      "{{ aws_region }}": "{{ aws_discovered_security_group }}"
+    all_aws_subnets_config:
+      "{{ aws_region }}": "{{ aws_discovered_subnets }}"
+    default_aws_region: "{{ aws_region }}"
+
 - name: Assert all required variables for AWS edges deployment
   ansible.builtin.include_role:
     name: common
@@ -63,6 +73,9 @@
     vbond: "{{ instance_item.vbond }}"
     system_ip: "{{ instance_item.system_ip }}"
     site_id: "{{ instance_item.site_id }}"
+    wan_edges_item: "{{ wan_edges | default([]) | json_query('[?uuid==`'~instance_item.uuid~'`] | [0]') }}"
+    region: "{{ wan_edges_item.aws_region | default(default_aws_region) }}"
+    ami: "{{ wan_edges_item.aws_cedge_ami_id | default(aws_cedge_ami_id) }}"
   loop: "{{ edge_instances }}"
   loop_control:
     loop_var: instance_item

--- a/roles/aws_network_infrastructure/defaults/main.yml
+++ b/roles/aws_network_infrastructure/defaults/main.yml
@@ -17,6 +17,7 @@ organization_name: null  # has to be set by user
 aws_region: null
 aws_resources_prefix: "{{ organization_name }}"
 aws_tag_creator: "{{ organization_name }}"
+all_aws_regions: "{{ [aws_region] + wan_edges | default([]) | json_query('[?aws_region].aws_region') | unique }}"
 
 # VPC
 aws_vpc_name: "{{ aws_resources_prefix }}-vpc"

--- a/roles/aws_network_infrastructure/tasks/main.yml
+++ b/roles/aws_network_infrastructure/tasks/main.yml
@@ -26,4 +26,11 @@
     mode: "0755"
 
 - name: Create network infrastructure on AWS
-  ansible.builtin.include_tasks: aws_create_network_infrastructure.yml
+  ansible.builtin.include_tasks:
+    file: aws_create_network_infrastructure.yml
+    apply:
+      vars:
+        aws_region: "{{ item }}"
+  loop: "{{ all_aws_regions }}"
+  loop_control:
+    label: "{{ item }}"

--- a/roles/aws_teardown/defaults/main.yml
+++ b/roles/aws_teardown/defaults/main.yml
@@ -17,6 +17,7 @@ teardown_specific_instances: false
 aws_region: null
 aws_resources_prefix: "{{ organization_name }}"
 aws_tag_creator: "{{ organization_name }}"
+all_aws_regions: "{{ [aws_region] + wan_edges | default([]) | json_query('[?aws_region].aws_region') | unique }}"
 
 aws_vpc_name: "{{ aws_resources_prefix }}-vpc"
 aws_security_group_name: "{{ aws_resources_prefix }}-sg"

--- a/roles/aws_teardown/tasks/main.yml
+++ b/roles/aws_teardown/tasks/main.yml
@@ -20,35 +20,31 @@
 # VPC info
 - name: Retrieve VPC details  # noqa: syntax-check[unknown-module]
   amazon.aws.ec2_vpc_net_info:  # noqa: syntax-check[unknown-module]
-    region: "{{ aws_region }}"
+    region: "{{ _region }}"
     filters:
       "tag:Name": "{{ aws_vpc_name }}"
       "tag:Creator": "{{ aws_tag_creator }}"
   register: vpc_info
+  loop: "{{ all_aws_regions }}"
+  loop_control:
+    label: "{{ _region }}"
+    loop_var: _region
 
 - name: Check if VPC info is not empty
   ansible.builtin.assert:
     that:
-      - vpc_info.vpcs | length > 0
+      - vpc_info.results | map(attribute='vpcs') | flatten | length > 0
     fail_msg: "No VPC found. Please check your VPC configuration. Might be that you already removed your configuration."
 
 - name: Set fact from register variable
   ansible.builtin.set_fact:
-    aws_vpc_id: "{{ vpc_info.vpcs[0].id }}"
-
-
-# SUBNET info
-- name: Gather information about all subnets in VPC
-  amazon.aws.ec2_vpc_subnet_info:
-    filters:
-      vpc-id: "{{ aws_vpc_id }}"
-    region: "{{ aws_region }}"
-  register: vpc_subnets
-
-- name: Set fact from register variable
-  ansible.builtin.set_fact:
-    aws_vpc_subnets: "{{ vpc_subnets }}"
-
+    aws_vpc_region: "{{ aws_vpc_region | default([]) + [{'vpc_id': _vpc.vpcs[0].id, 'region': _vpc._region}] }}"
+  loop:
+    "{{ vpc_info.results }}"
+  when: _vpc.vpcs
+  loop_control:
+    label: "{{ _vpc._region }}"
+    loop_var: _vpc
 
 #######################    Teardown    #######################
 
@@ -60,33 +56,82 @@
 - name: Stop and terminate ec2 instance
   ansible.builtin.include_tasks: ec2_instance.yml
   when: not teardown_specific_instances
+  loop: "{{ aws_vpc_region }}"
+  loop_control:
+    label: "{{ _vpc_region.region }}"
+    loop_var: _vpc_region
+  vars:
+    aws_region: "{{ _vpc_region.region }}"
+    aws_vpc_id: "{{ _vpc_region.vpc_id }}"
 
 # eip and network interfaces
 - name: Remove all network interfaces associated with VPC
   ansible.builtin.include_tasks: ec2_eni.yml
   when: not teardown_specific_instances
+  loop: "{{ aws_vpc_region }}"
+  loop_control:
+    label: "{{ _vpc_region.region }}"
+    loop_var: _vpc_region
+  vars:
+    aws_region: "{{ _vpc_region.region }}"
+    aws_vpc_id: "{{ _vpc_region.vpc_id }}"
 
 # security groups
 - name: Remove all security groups associated with VPC
   when: not teardown_specific_instances
   ansible.builtin.include_tasks: ec2_group.yml
+  loop: "{{ aws_vpc_region }}"
+  loop_control:
+    label: "{{ _vpc_region.region }}"
+    loop_var: _vpc_region
+  vars:
+    aws_region: "{{ _vpc_region.region }}"
+    aws_vpc_id: "{{ _vpc_region.vpc_id }}"
 
 # route tables
 - name: Remove all route tables associated with VPC
   when: not teardown_specific_instances
   ansible.builtin.include_tasks: ec2_vpc_route_table.yml
+  loop: "{{ aws_vpc_region }}"
+  loop_control:
+    label: "{{ _vpc_region.region }}"
+    loop_var: _vpc_region
+  vars:
+    aws_region: "{{ _vpc_region.region }}"
+    aws_vpc_id: "{{ _vpc_region.vpc_id }}"
 
 # subnets
 - name: Remove all subnets associated with VPC
   when: not teardown_specific_instances
   ansible.builtin.include_tasks: ec2_vpc_subnet.yml
+  loop: "{{ aws_vpc_region }}"
+  loop_control:
+    label: "{{ _vpc_region.region }}"
+    loop_var: _vpc_region
+  vars:
+    aws_region: "{{ _vpc_region.region }}"
+    aws_vpc_id: "{{ _vpc_region.vpc_id }}"
 
 # igw
 - name: Remove all internet gateways
   when: not teardown_specific_instances
   ansible.builtin.include_tasks: ec2_vpc_igw.yml
+  loop: "{{ aws_vpc_region }}"
+  loop_control:
+    label: "{{ _vpc_region.region }}"
+    loop_var: _vpc_region
+  vars:
+    aws_region: "{{ _vpc_region.region }}"
+    aws_vpc_id: "{{ _vpc_region.vpc_id }}"
 
 # vpc
 - name: Remove VPC
   when: not teardown_specific_instances
   ansible.builtin.include_tasks: ec2_vpc_net.yml
+  loop: "{{ aws_vpc_region }}"
+  loop_control:
+    label: "{{ _vpc_region.region }}"
+    loop_var: _vpc_region
+  vars:
+    aws_region: "{{ _vpc_region.region }}"
+    aws_vpc_id: "{{ _vpc_region.vpc_id }}"

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -1,0 +1,7 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+---
+
+# Common
+all_aws_regions: "{{ [aws_region] + wan_edges | default([]) | json_query('[?aws_region].aws_region') | unique }}"

--- a/roles/common/tasks/aws_existing_instances.yml
+++ b/roles/common/tasks/aws_existing_instances.yml
@@ -5,11 +5,15 @@
 # VPC info
 - name: Retrieve VPC details
   amazon.aws.ec2_vpc_net_info:  # noqa: syntax-check[unknown-module]
-    region: "{{ aws_region }}"
+    region: "{{ region }}"
     filters:
       "tag:Name": "{{ aws_vpc_config.tags.Name }}"
       "tag:Creator": "{{ aws_vpc_config.tags.Creator }}"
   register: ec2_vpc_net_info
+  loop: "{{ all_aws_regions }}"
+  loop_control:
+    label: "{{ region }}"
+    loop_var: region
 
 - name: Initialize instances_info dictionary
   ansible.builtin.set_fact:
@@ -17,17 +21,21 @@
 
 - name: Gather facts about all instances in VPC
   amazon.aws.ec2_instance_info:
-    region: "{{ aws_region }}"
+    region: "{{ vpc.region }}"
     filters:
-      vpc-id: "{{ ec2_vpc_net_info.vpcs[0].id }}"
+      vpc-id: "{{ vpc.vpcs[0].id }}"
       instance-state-name: ["pending", "running", "shutting-down", "stopping", "stopped"]
   register: ec2_instance_info
-  when: ec2_vpc_net_info.vpcs | length > 0
+  when: vpc.vpcs | length > 0
+  loop: "{{ ec2_vpc_net_info.results }}"
+  loop_control:
+    label: "{{ vpc.region }}"
+    loop_var: vpc
 
 
 # We are working inside one VPC, consider changing desing in order to maintain more VPCs.
 - name: Verify if there are instances with requested parameters already present
-  when: ec2_instance_info is defined and ec2_instance_info.instances | length > 0
+  when: ec2_instance_info is defined and ec2_instance_info.results | map(attribute='instances') | flatten | length > 0
   block:
     - name: Set instance status and state, variable 'instances_info' will hold list of existing instances
       ansible.builtin.set_fact:
@@ -35,9 +43,9 @@
           {{
             instances_info | default({}) | combine({
               instance_item.hostname: {
-                'state': (ec2_instance_info.instances | selectattr('tags.Name', 'equalto', instance_item.hostname) | map(attribute='state.name') | first)
+                'state': (ec2_instance_info.results | map(attribute='instances') | flatten | selectattr('tags.Name', 'equalto', instance_item.hostname) | map(attribute='state.name') | first)
               }
-            }) if instance_item.hostname in (ec2_instance_info.instances | map(attribute='tags.Name') | list) else instances_info
+            }) if instance_item.hostname in (ec2_instance_info.results | map(attribute='instances') | flatten | map(attribute='tags.Name') | list) else instances_info
           }}
       loop: "{{ instances_marked_for_deployment }}"
       loop_control:


### PR DESCRIPTION
# Pull Request summary:
Part of https://github.com/cisco-en-programmability/ansible-collection-sdwan/pull/41

This PR enables users to create Edges in regions different from the control components. In each region, the base network infrastructure will be provisioned, including VPC, subnets, and security group.

# Checklist:

- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
