### PR TITLE
Launch Azure Edges in multiple Azure regions

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -34,7 +34,7 @@ jobs:
         uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
 
       - name: Run ansible-lint
-        uses: ansible/ansible-lint@95382d398ea1744bf6bfa47b030f14c38b3f6957 # v24.7.0
+        uses: ansible/ansible-lint@v25.8.1
 
       - name: Install detect-secrets
         run: pip install detect-secrets==1.4.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/ansible-community/ansible-lint.git
-    rev: v24.2.1 # latest release tag from https://github.com/ansible-community/ansible-lint/releases/
+    rev: v25.8.1 # latest release tag from https://github.com/ansible-community/ansible-lint/releases/
     hooks:
       - id: ansible-lint
         files: \.(yaml|yml)$

--- a/roles/azure_edges/tasks/azure_cedge_vm.yml
+++ b/roles/azure_edges/tasks/azure_cedge_vm.yml
@@ -29,13 +29,13 @@
 
 - name: "Get info about NSG: {{ az_network_security_group }}"
   azure.azcollection.azure_rm_securitygroup_info:
-    resource_group: "{{ az_resource_group }}"
+    resource_group: "{{ az_default_resource_group }}"
     name: "{{ az_network_security_group }}"
   register: az_res_gr
 
 - name: "Extend Network Security Group for machine, NSG: {{ az_network_security_group }}"
   azure.azcollection.azure_rm_securitygroup:
-    resource_group: "{{ az_resource_group }}"
+    resource_group: "{{ az_default_resource_group }}"
     name: "{{ az_network_security_group }}"
     rules:
       - name: "{{ public_ip_state.state.name }}"

--- a/roles/azure_edges/tasks/main.yml
+++ b/roles/azure_edges/tasks/main.yml
@@ -44,6 +44,8 @@
   ansible.builtin.set_fact:
     deployment_facts:
       deployed_edge_instances: []
+    az_default_location: "{{ az_location }}"
+    az_default_resource_group: "{{ az_resource_group }}"
 
 - name: Create VM instance - cEdge (C8000V)
   ansible.builtin.include_tasks: azure_cedge_vm.yml
@@ -54,10 +56,18 @@
     vbond: "{{ instance_item.vbond }}"
     system_ip: "{{ instance_item.system_ip }}"
     site_id: "{{ instance_item.site_id }}"
+    wan_edges_item: "{{ wan_edges | default([]) | json_query('[?uuid==`'~instance_item.uuid~'`] | [0]') }}"
+    is_in_default_location: "{{ 'az_location' not in wan_edges_item or wan_edges_item['az_location'] == az_default_location }}"
+    az_resource_group: "{{ az_default_resource_group if is_in_default_location else az_resources_prefix~'-'~wan_edges_item['az_location']~'-rg' }}"
   loop: "{{ edge_instances }}"
   loop_control:
     loop_var: instance_item
-  when: edge_instances is defined and (instance_item.hostname not in instances_info or not instances_info[instance_item.hostname])
+  when:
+    - edge_instances is defined
+    - instance_item.hostname not in instances_info or not instances_info[instance_item.hostname]
+    - >
+      wan_edges is not defined
+      or wan_edges | json_query('[?uuid==`'~instance_item['uuid']~'`] | [?!contains(keys(@), `foreign`) || !foreign]')
 
 - name: Extract deployment facts
   ansible.builtin.include_role:

--- a/roles/azure_network_infrastructure/defaults/main.yml
+++ b/roles/azure_network_infrastructure/defaults/main.yml
@@ -12,6 +12,7 @@ organization_name: null  # has to be set by user
 az_location: null
 az_tag_creator: "{{ organization_name }}"
 az_resources_prefix: "{{ organization_name }}"  # default to organization_name, but user should have option to modify
+az_all_locations: "{{ [az_location] + wan_edges | default([]) | json_query('[?az_location].az_location') | unique }}"
 
 # Resource group
 az_resource_group: "{{ az_resources_prefix }}-rg"

--- a/roles/azure_network_infrastructure/tasks/main.yml
+++ b/roles/azure_network_infrastructure/tasks/main.yml
@@ -22,5 +22,18 @@
     state: directory
     mode: "0755"
 
+- name: Save default az_location
+  ansible.builtin.set_fact:
+    az_default_location: "{{ az_location }}"
+    az_default_resource_group: "{{ az_resources_prefix }}-rg"
+
 - name: "Network resources for SD-WAN machines"
-  ansible.builtin.include_tasks: azure_network_infrastructure.yml
+  ansible.builtin.include_tasks:
+    file: azure_network_infrastructure.yml
+    apply:
+      vars:
+        az_resource_group: "{{ az_default_resource_group if item == az_default_location else az_resources_prefix~'-'~item~'-rg' }}"
+        az_location: "{{ item }}"
+  loop: "{{ az_all_locations }}"
+  loop_control:
+    label: "{{ item }}"

--- a/roles/azure_teardown/defaults/main.yml
+++ b/roles/azure_teardown/defaults/main.yml
@@ -14,6 +14,7 @@ wait_for_teardown: true  # if set to false, teardown playbook will finish witout
 az_location: null
 az_tag_creator: "{{ organization_name }}"
 az_resources_prefix: "{{ organization_name }}"  # default to organization_name, but user should have option to modify
+az_all_locations: "{{ [az_location] + wan_edges | default([]) | json_query('[?az_location].az_location') | unique }}"
 
 # Resource group
 az_resource_group: "{{ az_resources_prefix }}-rg"

--- a/roles/azure_teardown/tasks/main.yml
+++ b/roles/azure_teardown/tasks/main.yml
@@ -9,6 +9,16 @@
 - name: "Replace underscores with hyphens in the az_resources_prefix string"
   ansible.builtin.set_fact:
     az_resources_prefix: "{{ az_resources_prefix | replace('_', '-') }}"
+    az_default_location: "{{ az_location }}"
+    az_default_resource_group: "{{ az_resources_prefix }}-rg"
 
 - name: Remove Azure Resource Group and wait for teardown completion
-  ansible.builtin.include_tasks: az_teardown_rg.yml
+  ansible.builtin.include_tasks:
+    file: az_teardown_rg.yml
+    apply:
+      vars:
+        az_resource_group: "{{ az_default_resource_group if item == az_default_location else az_resources_prefix~'-'~item~'-rg' }}"
+        az_location: "{{ item }}"
+  loop: "{{ az_all_locations }}"
+  loop_control:
+    label: "{{ item }}"


### PR DESCRIPTION
# Pull Request summary:
This PR provides similar functionality as https://github.com/cisco-en-programmability/ansible-collection-sdwan-deployment/pull/45 for Azure. 

This PR enables users to create Edges in regions different from the control components. In each region, the base network infrastructure will be provisioned, including resource grroup, network, and security group.

# Checklist:
- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
